### PR TITLE
(TWILL-80) Perform log force flush correctly. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -339,7 +339,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.14.1</version>
                 <configuration>
-                    <argLine>-Xmx1024m -XX:MaxPermSize=256m -Djava.awt.headless=true</argLine>
+                    <argLine>-Xmx2048m -XX:MaxPermSize=256m -Djava.awt.headless=true</argLine>
                     <redirectTestOutputToFile>${surefire.redirectTestOutputToFile}</redirectTestOutputToFile>
                     <systemPropertyVariables>
                         <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>

--- a/twill-common/pom.xml
+++ b/twill-common/pom.xml
@@ -41,7 +41,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/twill-common/src/main/java/org/apache/twill/common/CompositeService.java
+++ b/twill-common/src/main/java/org/apache/twill/common/CompositeService.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.twill.common;
+
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.util.concurrent.AbstractIdleService;
+import com.google.common.util.concurrent.Service;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Iterator;
+
+/**
+ * A {@link Service} that starts/stops list of services in order.
+ */
+public final class CompositeService extends AbstractIdleService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CompositeService.class);
+  private final Deque<Service> services;
+
+  public CompositeService(Service...services) {
+    this(ImmutableList.copyOf(services));
+  }
+
+  public CompositeService(Iterable<? extends Service> services) {
+    this.services = new ArrayDeque<Service>();
+    Iterables.addAll(this.services, services);
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    Throwable failureCause = null;
+
+    for (Service service : services) {
+      try {
+        service.startAndWait();
+      } catch (UncheckedExecutionException e) {
+        failureCause = e.getCause();
+        break;
+      }
+    }
+
+    if (failureCause != null) {
+      // Stop all running services and then throw the failure exception
+      try {
+        stopAll();
+      } catch (Throwable t) {
+        // Ignore the stop error. Just log.
+        LOG.warn("Failed when stopping all services on start failure", t);
+      }
+
+      Throwables.propagateIfPossible(failureCause, Exception.class);
+      throw new RuntimeException(failureCause);
+    }
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    stopAll();
+  }
+
+  private void stopAll() throws Exception {
+    Throwable failureCause = null;
+
+    // Stop services in reverse order.
+    Iterator<Service> itor = services.descendingIterator();
+    while (itor.hasNext()) {
+      Service service = itor.next();
+      try {
+        if (service.isRunning() || service.state() == State.STARTING) {
+          service.stopAndWait();
+        }
+      } catch (UncheckedExecutionException e) {
+        // Just catch as we want all services stopped
+        if (failureCause == null) {
+          failureCause = e.getCause();
+        } else {
+          // Log for sub-sequence service shutdown error, as only the first failure cause will be thrown.
+          LOG.warn("Failed to stop service {}", service, e);
+        }
+      }
+    }
+
+    if (failureCause != null) {
+      Throwables.propagateIfPossible(failureCause, Exception.class);
+      throw new RuntimeException(failureCause);
+    }
+  }
+}

--- a/twill-common/src/main/java/org/apache/twill/filesystem/LocalLocation.java
+++ b/twill-common/src/main/java/org/apache/twill/filesystem/LocalLocation.java
@@ -251,4 +251,9 @@ final class LocalLocation implements Location {
   public int hashCode() {
     return file.hashCode();
   }
+
+  @Override
+  public String toString() {
+    return file.toString();
+  }
 }

--- a/twill-common/src/test/java/org/apache/twill/common/CompositeServiceTest.java
+++ b/twill-common/src/test/java/org/apache/twill/common/CompositeServiceTest.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.twill.common;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.AbstractIdleService;
+import com.google.common.util.concurrent.Service;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Tests for {@link CompositeService}.
+ */
+public class CompositeServiceTest {
+
+  @Test
+  public void testOrder() throws InterruptedException, ExecutionException, TimeoutException {
+    List<Service> services = Lists.newArrayList();
+
+    // Start 10 services and check their start sequence is ordered.
+    Semaphore semaphore = new Semaphore(0);
+    for (int i = 0; i < 10; i++) {
+      services.add(new TestService(semaphore, i));
+    }
+
+    Service service = new CompositeService(services);
+    service.start().get(5, TimeUnit.SECONDS);
+
+    // There should be 10 permits after all 10 services started
+    Assert.assertTrue(semaphore.tryAcquire(10, 5, TimeUnit.SECONDS));
+
+    // Check all services are running
+    Assert.assertTrue(Iterables.all(services, serviceStatePredicate(Service.State.RUNNING)));
+
+    // Release 10 permits for the stop sequence to start
+    semaphore.release(10);
+    service.stop().get(5, TimeUnit.SECONDS);
+
+    // There should be no permit left after all 10 services stopped
+    Assert.assertFalse(semaphore.tryAcquire(10));
+
+    // Check all services are stopped
+    Assert.assertTrue(Iterables.all(services, serviceStatePredicate(Service.State.TERMINATED)));
+  }
+
+  @Test
+  public void testErrorStart() throws InterruptedException {
+    List<Service> services = Lists.newArrayList();
+
+    // Create 5 services. The forth one will got a start failure.
+    Semaphore semaphore = new Semaphore(0);
+    for (int i = 0; i < 5; i++) {
+      services.add(new TestService(semaphore, i, i == 3));
+    }
+
+    Service service = new CompositeService(services);
+    try {
+      service.start().get();
+      Assert.fail();
+    } catch (ExecutionException e) {
+      // Expected
+    }
+
+    // Verify all services are not in running state
+    Assert.assertTrue(Iterables.all(services, Predicates.not(serviceStatePredicate(Service.State.RUNNING))));
+
+    // There should be one service in error state
+    Assert.assertTrue(Iterables.removeIf(services, serviceStatePredicate(Service.State.FAILED)));
+
+    for (Service s : services) {
+      Assert.assertNotEquals(3, ((TestService) s).getOrder());
+    }
+  }
+
+  private Predicate<Service> serviceStatePredicate(final Service.State state) {
+    return new Predicate<Service>() {
+      @Override
+      public boolean apply(Service service) {
+        return service.state() == state;
+      }
+    };
+  }
+
+  private static final class TestService extends AbstractIdleService {
+
+    private final Semaphore semaphore;
+    private final int order;
+    private final boolean startFail;
+
+    private TestService(Semaphore semaphore, int order) {
+      this(semaphore, order, false);
+    }
+
+    private TestService(Semaphore semaphore, int order, boolean startFail) {
+      this.semaphore = semaphore;
+      this.order = order;
+      this.startFail = startFail;
+    }
+
+    public int getOrder() {
+      return order;
+    }
+
+    @Override
+    protected void startUp() throws Exception {
+      Preconditions.checkState(!startFail, "Fail to start service of order %s", order);
+
+      // Acquire all permits emitted by previous service
+      semaphore.acquire(order);
+      // Emit enough permits for next service
+      semaphore.release(order + 1);
+    }
+
+    @Override
+    protected void shutDown() throws Exception {
+      semaphore.acquire(order + 1);
+      semaphore.release(order);
+    }
+  }
+}

--- a/twill-core/src/main/java/org/apache/twill/internal/ApplicationBundler.java
+++ b/twill-core/src/main/java/org/apache/twill/internal/ApplicationBundler.java
@@ -142,20 +142,19 @@ public final class ApplicationBundler {
       } finally {
         jarOut.close();
       }
-      LOG.debug("copying temporary bundle to destination {} ({} bytes)", target.toURI(), tmpJar.length());
+      LOG.debug("copying temporary bundle to destination {} ({} bytes)", target, tmpJar.length());
       // Copy the tmp jar into destination.
-      OutputStream os = null; 
       try {
-        os = new BufferedOutputStream(target.getOutputStream());
-        Files.copy(tmpJar, os);
-      } catch (IOException e) {
-        throw new IOException("failed to copy bundle from " + tmpJar.toURI() + " to " + target.toURI(), e);
-      } finally {
-        if (os != null) {
+        OutputStream os = new BufferedOutputStream(target.getOutputStream());
+        try {
+          Files.copy(tmpJar, os);
+        } finally {
           os.close();
         }
+      } catch (IOException e) {
+        throw new IOException("failed to copy bundle from " + tmpJar.toURI() + " to " + target, e);
       }
-      LOG.debug("finished creating bundle at {}", target.toURI());
+      LOG.debug("finished creating bundle at {}", target);
     } finally {
       tmpJar.delete();
       LOG.debug("cleaned up local temporary for bundle {}", tmpJar.toURI());

--- a/twill-core/src/main/java/org/apache/twill/internal/TwillContainerLauncher.java
+++ b/twill-core/src/main/java/org/apache/twill/internal/TwillContainerLauncher.java
@@ -98,7 +98,7 @@ public final class TwillContainerLauncher {
                                                                  secureStoreLocation.length(), false, null));
       }
     } catch (IOException e) {
-      LOG.warn("Failed to launch container with secure store {}.", secureStoreLocation.toURI());
+      LOG.warn("Failed to launch container with secure store {}.", secureStoreLocation);
     }
 
     if (afterResources == null) {

--- a/twill-core/src/main/java/org/apache/twill/internal/logging/KafkaAppender.java
+++ b/twill-core/src/main/java/org/apache/twill/internal/logging/KafkaAppender.java
@@ -185,9 +185,9 @@ public final class KafkaAppender extends AppenderBase<ILoggingEvent> {
 
   public void forceFlush() {
     try {
-      publishLogs(2, TimeUnit.SECONDS);
+      scheduler.submit(flushTask).get(2, TimeUnit.SECONDS);
     } catch (Exception e) {
-      LOG.error("Failed to publish last batch of log.", e);
+      LOG.error("Failed to force log flush in 2 seconds.", e);
     }
   }
 
@@ -279,7 +279,7 @@ public final class KafkaAppender extends AppenderBase<ILoggingEvent> {
         try {
           int published = publishLogs(2L, TimeUnit.SECONDS);
           if (LOG.isDebugEnabled()) {
-            LOG.info("Published {} log messages to Kafka.", published);
+            LOG.debug("Published {} log messages to Kafka.", published);
           }
         } catch (Exception e) {
           LOG.error("Failed to push logs to Kafka. Log entries dropped.", e);

--- a/twill-yarn/src/main/java/org/apache/twill/filesystem/HDFSLocation.java
+++ b/twill-yarn/src/main/java/org/apache/twill/filesystem/HDFSLocation.java
@@ -238,4 +238,9 @@ final class HDFSLocation implements Location {
   public int hashCode() {
     return path.hashCode();
   }
+
+  @Override
+  public String toString() {
+    return path.toString();
+  }
 }

--- a/twill-yarn/src/main/java/org/apache/twill/internal/appmaster/ApplicationMasterMain.java
+++ b/twill-yarn/src/main/java/org/apache/twill/internal/appmaster/ApplicationMasterMain.java
@@ -17,7 +17,8 @@
  */
 package org.apache.twill.internal.appmaster;
 
-import com.google.common.util.concurrent.Service;
+import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.AbstractIdleService;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
@@ -26,15 +27,23 @@ import org.apache.twill.internal.Constants;
 import org.apache.twill.internal.EnvKeys;
 import org.apache.twill.internal.RunIds;
 import org.apache.twill.internal.ServiceMain;
+import org.apache.twill.internal.kafka.EmbeddedKafkaServer;
+import org.apache.twill.internal.logging.Loggings;
+import org.apache.twill.internal.utils.Networks;
 import org.apache.twill.internal.yarn.VersionDetectYarnAMClientFactory;
-import org.apache.twill.zookeeper.RetryStrategies;
+import org.apache.twill.internal.yarn.YarnAMClient;
+import org.apache.twill.zookeeper.ZKClient;
 import org.apache.twill.zookeeper.ZKClientService;
-import org.apache.twill.zookeeper.ZKClientServices;
-import org.apache.twill.zookeeper.ZKClients;
+import org.apache.twill.zookeeper.ZKOperations;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -56,18 +65,23 @@ public final class ApplicationMasterMain extends ServiceMain {
     File twillSpec = new File(Constants.Files.TWILL_SPEC);
     RunId runId = RunIds.fromString(System.getenv(EnvKeys.TWILL_RUN_ID));
 
-    ZKClientService zkClientService =
-      ZKClientServices.delegate(
-        ZKClients.reWatchOnExpire(
-          ZKClients.retryOnFailure(
-            ZKClientService.Builder.of(zkConnect).build(),
-            RetryStrategies.fixDelay(1, TimeUnit.SECONDS))));
-
+    ZKClientService zkClientService = createZKClient(zkConnect);
     Configuration conf = new YarnConfiguration(new HdfsConfiguration(new Configuration()));
     setRMSchedulerAddress(conf);
-    Service service = new ApplicationMasterService(runId, zkClientService, twillSpec,
-                                                   new VersionDetectYarnAMClientFactory(conf), createAppLocation(conf));
-    new ApplicationMasterMain(String.format("%s/%s/kafka", zkConnect, runId.getId())).doMain(zkClientService, service);
+
+    final YarnAMClient amClient = new VersionDetectYarnAMClientFactory(conf).create();
+    ApplicationMasterService service = new ApplicationMasterService(runId, zkClientService,
+                                                                    twillSpec, amClient, createAppLocation(conf));
+    TrackerService trackerService = new TrackerService(service);
+
+    new ApplicationMasterMain(String.format("%s/%s/kafka", zkConnect, runId.getId()))
+      .doMain(
+        service,
+        new YarnAMClientService(amClient, trackerService),
+        zkClientService,
+        new TwillZKPathService(zkClientService, runId),
+        new ApplicationKafkaService(zkClientService, runId)
+      );
   }
 
   /**
@@ -104,5 +118,109 @@ public final class ApplicationMasterMain extends ServiceMain {
   @Override
   protected String getRunnableName() {
     return System.getenv(EnvKeys.TWILL_RUNNABLE_NAME);
+  }
+
+
+  /**
+   * A service wrapper for starting/stopping {@link EmbeddedKafkaServer} and make sure the ZK path for
+   * Kafka exists before starting the Kafka server.
+   */
+  private static final class ApplicationKafkaService extends AbstractIdleService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ApplicationKafkaService.class);
+
+    private final ZKClient zkClient;
+    private final String kafkaZKPath;
+    private final EmbeddedKafkaServer kafkaServer;
+
+    private ApplicationKafkaService(ZKClient zkClient, RunId runId) {
+      this.zkClient = zkClient;
+      this.kafkaZKPath = "/" + runId.getId() + "/kafka";
+      this.kafkaServer = new EmbeddedKafkaServer(generateKafkaConfig(zkClient.getConnectString() + kafkaZKPath));
+    }
+
+    @Override
+    protected void startUp() throws Exception {
+      ZKOperations.ignoreError(
+        zkClient.create(kafkaZKPath, null, CreateMode.PERSISTENT),
+        KeeperException.NodeExistsException.class, kafkaZKPath).get();
+      kafkaServer.startAndWait();
+    }
+
+    @Override
+    protected void shutDown() throws Exception {
+      // Flush all logs before shutting down Kafka server
+      Loggings.forceFlush();
+      // Delay for 2 seconds to give clients chance to poll the last batch of log messages.
+      try {
+        TimeUnit.SECONDS.sleep(2);
+      } catch (InterruptedException e) {
+        // Ignore
+        LOG.info("Kafka shutdown delay interrupted", e);
+      } finally {
+        kafkaServer.stopAndWait();
+      }
+    }
+
+    private Properties generateKafkaConfig(String kafkaZKConnect) {
+      int port = Networks.getRandomPort();
+      Preconditions.checkState(port > 0, "Failed to get random port.");
+
+      Properties prop = new Properties();
+      prop.setProperty("log.dir", new File("kafka-logs").getAbsolutePath());
+      prop.setProperty("port", Integer.toString(port));
+      prop.setProperty("broker.id", "1");
+      prop.setProperty("socket.send.buffer.bytes", "1048576");
+      prop.setProperty("socket.receive.buffer.bytes", "1048576");
+      prop.setProperty("socket.request.max.bytes", "104857600");
+      prop.setProperty("num.partitions", "1");
+      prop.setProperty("log.retention.hours", "24");
+      prop.setProperty("log.flush.interval.messages", "10000");
+      prop.setProperty("log.flush.interval.ms", "1000");
+      prop.setProperty("log.segment.bytes", "536870912");
+      prop.setProperty("zookeeper.connect", kafkaZKConnect);
+      prop.setProperty("zookeeper.connection.timeout.ms", "1000000");
+      prop.setProperty("default.replication.factor", "1");
+      return prop;
+    }
+  }
+
+
+  /**
+   * A Service wrapper that starts {@link TrackerService} and {@link YarnAMClient}. It is needed because
+   * the tracker host and url needs to be provided to {@link YarnAMClient} before it starts {@link YarnAMClient}.
+   */
+  private static final class YarnAMClientService extends AbstractIdleService {
+
+    private final YarnAMClient yarnAMClient;
+    private final TrackerService trackerService;
+
+    private YarnAMClientService(YarnAMClient yarnAMClient, TrackerService trackerService) {
+      this.yarnAMClient = yarnAMClient;
+      this.trackerService = trackerService;
+    }
+
+    @Override
+    protected void startUp() throws Exception {
+      trackerService.setHost(yarnAMClient.getHost());
+      trackerService.startAndWait();
+
+      yarnAMClient.setTracker(trackerService.getBindAddress(), trackerService.getUrl());
+      try {
+        yarnAMClient.startAndWait();
+      } catch (Exception e) {
+        trackerService.stopAndWait();
+        throw e;
+      }
+    }
+
+    @Override
+    protected void shutDown() throws Exception {
+      try {
+        yarnAMClient.stopAndWait();
+      } finally {
+        trackerService.stopAndWait();
+      }
+    }
   }
 }

--- a/twill-yarn/src/main/java/org/apache/twill/internal/yarn/AbstractYarnTwillService.java
+++ b/twill-yarn/src/main/java/org/apache/twill/internal/yarn/AbstractYarnTwillService.java
@@ -93,7 +93,7 @@ public abstract class AbstractYarnTwillService extends AbstractTwillService {
       UserGroupInformation.getCurrentUser().addCredentials(credentials);
       this.credentials = credentials;
 
-      LOG.info("Secure store updated from {}.", location.toURI());
+      LOG.info("Secure store updated from {}.", location);
 
     } catch (Throwable t) {
       LOG.error("Failed to update secure store.", t);

--- a/twill-yarn/src/main/java/org/apache/twill/yarn/YarnTwillPreparer.java
+++ b/twill-yarn/src/main/java/org/apache/twill/yarn/YarnTwillPreparer.java
@@ -329,7 +329,7 @@ final class YarnTwillPreparer implements TwillPreparer {
 
       List<Token<?>> tokens = YarnUtils.addDelegationTokens(yarnConfig, locationFactory, credentials);
       for (Token<?> token : tokens) {
-        LOG.debug("Delegation token acquired for {}, {}", locationFactory.getHomeLocation().toURI(), token);
+        LOG.debug("Delegation token acquired for {}, {}", locationFactory.getHomeLocation(), token);
       }
     } catch (IOException e) {
       LOG.warn("Failed to check for secure login type. Not gathering any delegation token.", e);

--- a/twill-yarn/src/main/java/org/apache/twill/yarn/YarnTwillRunnerService.java
+++ b/twill-yarn/src/main/java/org/apache/twill/yarn/YarnTwillRunnerService.java
@@ -601,7 +601,7 @@ public final class YarnTwillRunnerService extends AbstractIdleService implements
     // Rename the tmp file into the credentials location
     tmpLocation.renameTo(credentialsLocation);
 
-    LOG.debug("Secure store for {} {} saved to {}.", application, runId, credentialsLocation.toURI());
+    LOG.debug("Secure store for {} {} saved to {}.", application, runId, credentialsLocation);
   }
 
   private static LocationFactory createDefaultLocationFactory(Configuration configuration) {

--- a/twill-yarn/src/test/java/org/apache/twill/yarn/SessionExpireTestRun.java
+++ b/twill-yarn/src/test/java/org/apache/twill/yarn/SessionExpireTestRun.java
@@ -21,6 +21,7 @@ import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.Service;
+import com.google.common.util.concurrent.Uninterruptibles;
 import org.apache.twill.api.AbstractTwillRunnable;
 import org.apache.twill.api.TwillController;
 import org.apache.twill.api.TwillRunner;
@@ -94,7 +95,7 @@ public class SessionExpireTestRun extends BaseYarnTest {
     QueryExp query = Query.isInstanceOf(new StringValueExp(ConnectionMXBean.class.getName()));
 
     Stopwatch stopwatch = new Stopwatch();
-
+    stopwatch.start();
     do {
       // Find the AM session and expire it
       Set<ObjectName> connectionBeans = mbeanServer.queryNames(ObjectName.WILDCARD, query);
@@ -111,6 +112,7 @@ public class SessionExpireTestRun extends BaseYarnTest {
           }
         }
       }
+      Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
     } while (stopwatch.elapsedTime(timeoutUnit) < timeout);
 
     return false;

--- a/twill-zookeeper/src/main/java/org/apache/twill/internal/zookeeper/DefaultZKClientService.java
+++ b/twill-zookeeper/src/main/java/org/apache/twill/internal/zookeeper/DefaultZKClientService.java
@@ -424,18 +424,19 @@ public final class DefaultZKClientService extends AbstractZKClient implements ZK
     public void process(WatchedEvent event) {
       try {
         if (event.getState() == Event.KeeperState.SyncConnected && state() == State.STARTING) {
-          LOG.debug("Connected to ZooKeeper: " + zkStr);
+          LOG.debug("Connected to ZooKeeper: {}", zkStr);
           notifyStarted();
           return;
         }
         if (event.getState() == Event.KeeperState.Expired) {
-          LOG.info("ZooKeeper session expired: " + zkStr);
+          LOG.info("ZooKeeper session expired: {}", zkStr);
 
           // When connection expired, simply reconnect again
           Thread t = new Thread(new Runnable() {
             @Override
             public void run() {
               try {
+                LOG.info("Reconnect to ZooKeeper due to expiration: {}", zkStr);
                 zooKeeper.set(createZooKeeper());
               } catch (IOException e) {
                 zooKeeper.set(null);


### PR DESCRIPTION
Also there are refactoring around service starts/stops for container (both AM and runnable) to have a cleaner view on the service dependencies. The help making sure unregistration to RM is done last on AM, providing a more accurate view for RM.