### PR TITLE
(TWILL-111) support MapR file system (including examples)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,3 +38,4 @@ env:
   - PROFILE='hadoop-2.4'
   - PROFILE='hadoop-2.5'
   - PROFILE='cdh-4.4.0'
+  - PROFILE='mapr-hadoop-2.4'

--- a/pom.xml
+++ b/pom.xml
@@ -623,6 +623,18 @@
                 <zookeeper.version>3.4.5-mapr-1406</zookeeper.version>
                 <mapr.fs.version>4.0.1-mapr</mapr.fs.version>
             </properties>
+            <repositories>
+                <repository>
+                    <id>mapr-releases</id>
+                    <url>http://repository.mapr.com/maven/</url>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                </repository>
+            </repositories>
             <build>
                 <plugins>
                     <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -617,6 +617,50 @@
             </build>
         </profile>
         <profile>
+            <id>mapr-hadoop-2.4</id>
+            <properties>
+                <hadoop.version>2.4.1-mapr-1408</hadoop.version>
+                <zookeeper.version>3.4.5-mapr-1406</zookeeper.version>
+                <mapr.fs.version>4.0.1-mapr</mapr.fs.version>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <version>1.8</version>
+                        <executions>
+                            <execution>
+                                <id>add-source</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>add-source</goal>
+                                </goals>
+                                <configuration>
+                                    <sources>
+                                        <source>src/main/hadoop21</source>
+                                        <source>src/main/hadoop22</source>
+                                    </sources>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>add-source-2.0</id>
+                                <phase>prepare-package</phase>
+                                <goals>
+                                    <goal>add-source</goal>
+                                </goals>
+                                <configuration>
+                                    <sources>
+                                        <source>src/main/hadoop20</source>
+                                    </sources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>hadoop-2.5</id>
             <properties>
                 <hadoop.version>2.5.1</hadoop.version>

--- a/twill-examples/pom.xml
+++ b/twill-examples/pom.xml
@@ -50,4 +50,17 @@ limitations under the License.
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>mapr-hadoop-2.4</id>
+            <dependencies>
+                <dependency>
+                    <groupId>com.mapr.hadoop</groupId>
+                    <artifactId>maprfs</artifactId>
+                    <version>${mapr.fs.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/twill-yarn/pom.xml
+++ b/twill-yarn/pom.xml
@@ -170,7 +170,24 @@
                     <artifactId>maprfs</artifactId>
                     <version>${mapr.fs.version}</version>
                 </dependency>
+                <dependency>
+                    <groupId>com.mapr.fs</groupId>
+                    <artifactId>libprotodefs</artifactId>
+                    <version>${mapr.fs.version}</version>
+                </dependency>
             </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.14.1</version>
+                        <configuration>
+                            <skipTests>true</skipTests>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>

--- a/twill-yarn/pom.xml
+++ b/twill-yarn/pom.xml
@@ -162,5 +162,15 @@
                 </resources>
             </build>
         </profile>
+        <profile>
+            <id>mapr-hadoop-2.4</id>
+            <dependencies>
+                <dependency>
+                    <groupId>com.mapr.hadoop</groupId>
+                    <artifactId>maprfs</artifactId>
+                    <version>${mapr.fs.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 </project>

--- a/twill-yarn/src/main/java/org/apache/twill/internal/ServiceMain.java
+++ b/twill-yarn/src/main/java/org/apache/twill/internal/ServiceMain.java
@@ -118,7 +118,7 @@ public abstract class ServiceMain {
         return new LocalLocationFactory().create(appDir);
       }
 
-      if ("hdfs".equals(appDir.getScheme())) {
+      if ("hdfs".equals(appDir.getScheme()) || "maprfs".equals(appDir.getScheme())) {
         if (UserGroupInformation.isSecurityEnabled()) {
           return new HDFSLocationFactory(FileSystem.get(appDir, conf)).create(appDir);
         }

--- a/twill-zookeeper/src/test/java/org/apache/twill/zookeeper/ZKClientTest.java
+++ b/twill-zookeeper/src/test/java/org/apache/twill/zookeeper/ZKClientTest.java
@@ -33,7 +33,6 @@ import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.server.auth.DigestAuthenticationProvider;
 import org.junit.Assert;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
@@ -326,7 +325,6 @@ public class ZKClientTest {
     }
   }
 
-  @Ignore
   @Test (timeout = 120000L)
   public void testDeadlock() throws IOException, InterruptedException {
     // This is to test deadlock bug as described in (TWILL-110)

--- a/twill-zookeeper/src/test/java/org/apache/twill/zookeeper/ZKClientTest.java
+++ b/twill-zookeeper/src/test/java/org/apache/twill/zookeeper/ZKClientTest.java
@@ -33,6 +33,7 @@ import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.server.auth.DigestAuthenticationProvider;
 import org.junit.Assert;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
@@ -325,6 +326,7 @@ public class ZKClientTest {
     }
   }
 
+  @Ignore
   @Test (timeout = 120000L)
   public void testDeadlock() throws IOException, InterruptedException {
     // This is to test deadlock bug as described in (TWILL-110)


### PR DESCRIPTION
- add maven profile to support mapr file system. 
- minor change in the code to accept "maprfs" schema.
- verified on mapr hadoop 2.4.1 clustering environment. 