### PR TITLE
(TWILL-125) Eliminate mainObject instance in BundedJarRunner

### DIFF
--- a/twill-ext/src/main/java/org/apache/twill/ext/BundledJarRunner.java
+++ b/twill-ext/src/main/java/org/apache/twill/ext/BundledJarRunner.java
@@ -57,7 +57,6 @@ public class BundledJarRunner {
 
   private final File jarFile;
   private final Arguments arguments;
-  private Object mainObject;
   private Method mainMethod;
 
   public BundledJarRunner(File jarFile, Arguments arguments) {
@@ -108,18 +107,16 @@ public class BundledJarRunner {
     LOG.debug("Instantiating instance of " + mainClassName);
     Class<?> cls = classLoader.loadClass(mainClassName);
     mainMethod = cls.getMethod("main", String[].class);
-    mainObject = cls.newInstance();
   }
 
   public void run() throws Throwable {
     Preconditions.checkNotNull(mainMethod, "Must call load() first");
-    Preconditions.checkNotNull(mainObject, "Must call load() first");
     String mainClassName = arguments.getMainClassName();
     String[] args = arguments.getMainArgs();
 
     try {
       LOG.info("Invoking " + mainClassName + ".main(" + Arrays.toString(args) + ")");
-      mainMethod.invoke(mainObject, new Object[] { args });
+      mainMethod.invoke(null, new Object[] { args });
     } catch (Throwable t) {
       LOG.error("Error while trying to run " + mainClassName + " within " + jarFile.getAbsolutePath(), t);
       throw t;

--- a/twill-ext/src/test/java/org/apache/twill/ext/BundledJarRunnerTest.java
+++ b/twill-ext/src/test/java/org/apache/twill/ext/BundledJarRunnerTest.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.twill.ext;
+
+import com.google.common.io.ByteStreams;
+import com.google.common.io.Files;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.IOException;
+import java.util.jar.JarOutputStream;
+import java.util.zip.ZipEntry;
+
+/**
+ * Tests for {@link BundledJarRunner}.
+ */
+public class BundledJarRunnerTest {
+
+  private static String jarOutput;
+
+  static class Simple {
+    public static void main(String[] args) {
+      jarOutput = args[0];
+    }
+  }
+
+  static class NoZeroArgsConstructor {
+    public static void main(String[] args) {
+      NoZeroArgsConstructor obj = new NoZeroArgsConstructor(args[0]);
+    }
+    public NoZeroArgsConstructor(String arg) {
+      jarOutput = arg;
+    }
+  }
+
+  @Test
+  public void runSimpleJar() throws Throwable {
+    String output = "Simple";
+    String jarFileName = "simple.jar";
+    String className = "org.apache.twill.ext.BundledJarRunnerTest$Simple";
+    runJarFile(jarFileName, className, new String[]{output});
+    Assert.assertEquals(jarOutput, output);
+  }
+
+  @Test
+  public void runNoZeroArgsConstructorJar() throws Throwable {
+    String output = "NoZeroArgsConstructor";
+    String jarFileName = "nozeroargs.jar";
+    String className = "org.apache.twill.ext.BundledJarRunnerTest$NoZeroArgsConstructor";
+    runJarFile(jarFileName, className, new String[]{output});
+    Assert.assertEquals(jarOutput, output);
+  }
+
+  private void runJarFile(String jarFileName, String className, String[] mainArgs) throws Throwable {
+    File outdir = Files.createTempDir();
+    try {
+      File jarfile = new File(outdir, jarFileName);
+      createJarFileFromClass(className, jarfile);
+      BundledJarRunner.Arguments args = new BundledJarRunner.Arguments(
+          jarFileName, "lib", className, mainArgs);
+      BundledJarRunner jarRunner = new BundledJarRunner(jarfile, args);
+      jarRunner.load();
+      jarRunner.run();
+    } finally {
+      cleanDirectory(outdir);
+      outdir.delete();
+    }
+  }
+
+  private void createJarFileFromClass(String className, File jarfile) throws IOException {
+    String classAsPath = className.replace(".", "/") + ".class";
+    String packagePath = classAsPath.substring(0, classAsPath.lastIndexOf("/") + 1);
+    FileOutputStream fout = null;
+    JarOutputStream jarout = null;
+    try {
+      fout = new FileOutputStream(jarfile.getAbsolutePath());
+      jarout = new JarOutputStream(fout);
+      jarout.putNextEntry(new ZipEntry(packagePath));
+      jarout.putNextEntry(new ZipEntry(classAsPath));
+      jarout.write(getClassBytes(classAsPath));
+      jarout.closeEntry();
+    } finally {
+      jarout.close();
+      fout.close();
+    }
+  }
+
+  private byte[] getClassBytes(String classAsPath) throws IOException {
+    InputStream input = getClass().getClassLoader().getResourceAsStream(classAsPath);
+    return ByteStreams.toByteArray(input);
+  }
+
+  private void cleanDirectory(File dir) {
+    File[] files = dir.listFiles();
+    if (files == null) {
+      return;
+    }
+    for (File file: files) {
+      if (file.isDirectory()) {
+        cleanDirectory(file);
+      }
+      file.delete();
+    }
+  }
+}
+


### PR DESCRIPTION
Instantiating the object containing the main method in order to invoke
the main method is unnecessary since main is always static. There is
also a potential problem with calling newInstance() on the main object's
class; it will throw an exception if the main object does not have
a 0-args constructor.