### PR TITLE
TWILL-126 Use Travis CI container-based testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,3 +39,9 @@ env:
   - PROFILE='hadoop-2.5'
   - PROFILE='cdh-4.4.0'
   - PROFILE='mapr-hadoop-2.4'
+
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.m2


### PR DESCRIPTION
This updates Twill to use the Travis CI container-based infrastructure and S3 caching for Maven-downloaded resources. The `.travis.yml` has been validated using [Travis Lint](http://lint.travis-ci.org/) and is valid.