### PR TITLE
[Twill-117] adding hadoop classpath to the AM Container launch

### DIFF
--- a/twill-api/src/main/java/org/apache/twill/api/ClassAcceptor.java
+++ b/twill-api/src/main/java/org/apache/twill/api/ClassAcceptor.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.twill.api;
+
+import java.net.URL;
+
+/**
+ * Class that can be used to determine if class can be accepted.
+ */
+public class ClassAcceptor {
+  /**
+   * Invoked to determine if class can be accepted. default behavior returns true.
+   *
+   * @param className Name of the class.
+   * @param classUrl URL for the class resource.
+   * @param classPathUrl URL for the class path resource that contains the class resource.
+   *                     If the URL protocol is {@code file}, it would be the path to root package.
+   *                     If the URL protocol is {@code jar}, it would be the jar file.
+   * @return true to accept the given class, false otherwise.
+   */
+  public boolean accept(String className, URL classUrl, URL classPathUrl) {
+    return true;
+  }
+}

--- a/twill-api/src/main/java/org/apache/twill/api/TwillPreparer.java
+++ b/twill-api/src/main/java/org/apache/twill/api/TwillPreparer.java
@@ -179,6 +179,26 @@ public interface TwillPreparer {
   TwillPreparer withClassPaths(Iterable<String> classPaths);
 
   /**
+   * Adds the set of paths to the classpath on the target machine for ApplicationMaster and all runnables.
+   * @return This {@link TwillPreparer}
+   */
+  TwillPreparer withApplicationClassPaths(String... classPaths);
+
+  /**
+   * Adds the set of paths to the classpath on the target machine for ApplicationMaster and all runnables.
+   * @return This {@link TwillPreparer}
+   */
+  TwillPreparer withApplicationClassPaths(Iterable<String> classPaths);
+
+  /**
+   * Uses {@link ClassAcceptor} to determine the classes to include in the bundle jar for
+   * ApplicationMaster and all runnables.
+   * @param classAcceptor to specify which classes to include in the bundle jar
+   * @return This {@link TwillPreparer}
+   */
+  TwillPreparer withBundlerClassAcceptor(ClassAcceptor classAcceptor);
+
+  /**
    * Adds security credentials for the runtime environment to gives application access to resources.
    *
    * @param secureStore Contains security token available for the runtime environment.

--- a/twill-core/src/main/java/org/apache/twill/internal/Constants.java
+++ b/twill-core/src/main/java/org/apache/twill/internal/Constants.java
@@ -45,6 +45,8 @@ public final class Constants {
   public static final String STDOUT = "stdout";
   public static final String STDERR = "stderr";
 
+  public static final String CLASSPATH = "classpath";
+  public static final String APPLICATION_CLASSPATH = "application-classpath";
   /**
    * Constants for names of internal files that are shared between client, AM and containers.
    */

--- a/twill-core/src/main/java/org/apache/twill/internal/utils/Dependencies.java
+++ b/twill-core/src/main/java/org/apache/twill/internal/utils/Dependencies.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.io.ByteStreams;
+import org.apache.twill.api.ClassAcceptor;
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
@@ -46,23 +47,6 @@ import java.util.Set;
  * Utility class to help find out class dependencies.
  */
 public final class Dependencies {
-
-  /**
-   * Represents a callback for accepting a class during dependency traversal.
-   */
-  public interface ClassAcceptor {
-    /**
-     * Invoked when a class is being found as a dependency.
-     *
-     * @param className Name of the class.
-     * @param classUrl URL for the class resource.
-     * @param classPathUrl URL for the class path resource that contains the class resource.
-     *                     If the URL protocol is {@code file}, it would be the path to root package.
-     *                     If the URL protocol is {@code jar}, it would be the jar file.
-     * @return true keep finding dependencies on the given class.
-     */
-    boolean accept(String className, URL classUrl, URL classPathUrl);
-  }
 
   public static void findClassDependencies(ClassLoader classLoader,
                                            ClassAcceptor acceptor,

--- a/twill-core/src/main/java/org/apache/twill/launcher/TwillLauncher.java
+++ b/twill-core/src/main/java/org/apache/twill/launcher/TwillLauncher.java
@@ -17,6 +17,8 @@
  */
 package org.apache.twill.launcher;
 
+import org.apache.twill.internal.Constants;
+
 import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
 import java.io.File;
@@ -156,26 +158,30 @@ public final class TwillLauncher {
       }
 
       if (useClassPath) {
-        InputStream is = ClassLoader.getSystemResourceAsStream("classpath");
-        if (is != null) {
-          try {
-            BufferedReader reader = new BufferedReader(new InputStreamReader(is, Charset.forName("UTF-8")));
-            String line = reader.readLine();
-            if (line != null) {
-              for (String path : line.split(":")) {
-                urls.addAll(getClassPaths(path));
-              }
-            }
-          } finally {
-            is.close();
-          }
-        }
+        addClassPathsToList(urls, Constants.CLASSPATH);
       }
+
+      addClassPathsToList(urls, Constants.APPLICATION_CLASSPATH);
 
       return new URLClassLoader(urls.toArray(new URL[0]));
 
     } catch (Exception e) {
       throw new IllegalStateException(e);
+    }
+  }
+
+  private static void addClassPathsToList(List<URL> urls, String resource) throws IOException {
+    try (InputStream is = ClassLoader.getSystemResourceAsStream(resource)) {
+      if (is != null) {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(is, Charset.forName("UTF-8")))) {
+          String line = reader.readLine();
+          if (line != null) {
+            for (String path : line.split(":")) {
+              urls.addAll(getClassPaths(path.trim()));
+            }
+          }
+        }
+      }
     }
   }
 

--- a/twill-examples/yarn/src/main/java/org/apache/twill/example/yarn/HelloWorld.java
+++ b/twill-examples/yarn/src/main/java/org/apache/twill/example/yarn/HelloWorld.java
@@ -17,9 +17,14 @@
  */
 package org.apache.twill.example.yarn;
 
+import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.Futures;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.twill.api.AbstractTwillRunnable;
+import org.apache.twill.api.ClassAcceptor;
 import org.apache.twill.api.TwillController;
 import org.apache.twill.api.TwillRunnerService;
 import org.apache.twill.api.logging.PrinterLogHandler;
@@ -28,6 +33,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.PrintWriter;
+import java.net.URL;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 /**
@@ -57,15 +64,22 @@ public class HelloWorld {
     }
 
     String zkStr = args[0];
-
+    YarnConfiguration yarnConfiguration = new YarnConfiguration();
     final TwillRunnerService twillRunner =
       new YarnTwillRunnerService(
-        new YarnConfiguration(), zkStr);
+        yarnConfiguration, zkStr);
     twillRunner.start();
 
+    String yarnClasspath =
+      yarnConfiguration.get(YarnConfiguration.YARN_APPLICATION_CLASSPATH,
+                            Joiner.on(",").join(YarnConfiguration.DEFAULT_YARN_APPLICATION_CLASSPATH));
+    List<String> applicationClassPaths = Lists.newArrayList();
+    Iterables.addAll(applicationClassPaths, Splitter.on(",").split(yarnClasspath));
     final TwillController controller =
       twillRunner.prepare(new HelloWorldRunnable())
         .addLogHandler(new PrinterLogHandler(new PrintWriter(System.out, true)))
+        .withApplicationClassPaths(applicationClassPaths)
+        .withBundlerClassAcceptor(new HadoopClassExcluder())
         .start();
 
     Runtime.getRuntime().addShutdownHook(new Thread() {
@@ -83,6 +97,17 @@ public class HelloWorld {
       controller.awaitTerminated();
     } catch (ExecutionException e) {
       e.printStackTrace();
+    }
+  }
+
+  static class HadoopClassExcluder extends ClassAcceptor {
+    @Override
+    public boolean accept(String className, URL classUrl, URL classPathUrl) {
+      // exclude hadoop but not hbase package
+      if (className.startsWith("org.apache.hadoop") && !className.startsWith("org.apache.hadoop.hbase")) {
+        return false;
+      }
+      return true;
     }
   }
 }


### PR DESCRIPTION
we add hadoop_classpath to the AM container classpath, so address the issue mentioned here, https://issues.apache.org/jira/browse/TWILL-117

UPDATE  : Based on code review comments, have updated this PR, now the TwillPreparer API has two new methods , withPredicate(predicate) and includeApplicationClassPath(Iterable<String> classpath), so the functionality is more generic, and we can add any classes to the AM classpath and runnable and apply the custom predicate while building the bundler jar. 