### PR TITLE
(TWILL-141) Fix namespacing of ZKClient

### DIFF
--- a/twill-zookeeper/src/main/java/org/apache/twill/internal/zookeeper/SettableOperationFuture.java
+++ b/twill-zookeeper/src/main/java/org/apache/twill/internal/zookeeper/SettableOperationFuture.java
@@ -35,7 +35,7 @@ public final class SettableOperationFuture<V> extends AbstractFuture<V> implemen
   private final Executor executor;
 
   public static <V> SettableOperationFuture<V> create(String path, Executor executor) {
-    return new SettableOperationFuture<V>(path, executor);
+    return new SettableOperationFuture<>(path, executor);
   }
 
   private SettableOperationFuture(String requestPath, Executor executor) {


### PR DESCRIPTION
- Not to fail with exception when creating “/“ through the
  namespaced ZKClient
- Return the correct path in OperationFuture.getRequestPath() for
  futures returned from namespaced ZKClient