### PR TITLE
TWILL-151 Improve Logging error when fetching message after Kafka server

### DIFF
--- a/twill-core/src/main/java/org/apache/twill/internal/kafka/client/SimpleKafkaConsumer.java
+++ b/twill-core/src/main/java/org/apache/twill/internal/kafka/client/SimpleKafkaConsumer.java
@@ -380,11 +380,10 @@ final class SimpleKafkaConsumer implements KafkaConsumer {
           invokeCallback(messages, offset);
         } catch (Throwable t) {
           // Only log if it is still running, otherwise, it just the interrupt caused by the stop.
-          String expMsg = "Unable to fetch messages on {},service shutdown is in progress.";
           if (!running) {
-            LOG.debug(expMsg, topicPart);
+            LOG.debug("Unable to fetch messages on {}, kafka consumer service shutdown is in progress.", topicPart);
           } else if (running && (t instanceof ClosedByInterruptException || t instanceof ConnectException)) {
-            LOG.debug(expMsg, topicPart);  
+            LOG.debug("Unable to fetch messages on {}, kafka server shutdown is in progress.", topicPart);  
           } else {
             LOG.info("Exception when fetching message on {}.", topicPart, t);
           }

--- a/twill-core/src/main/java/org/apache/twill/internal/kafka/client/SimpleKafkaConsumer.java
+++ b/twill-core/src/main/java/org/apache/twill/internal/kafka/client/SimpleKafkaConsumer.java
@@ -376,8 +376,10 @@ final class SimpleKafkaConsumer implements KafkaConsumer {
           // Call the callback
           invokeCallback(messages, offset);
         } catch (Throwable t) {
-          if (running || !(t instanceof ClosedByInterruptException)) {
-            // Only log if it is still running, otherwise, it just the interrupt caused by the stop.
+          if (!running) {
+            LOG.debug("Unable to fetch messages on {}.Service shutdown is in progress.", topicPart);
+          } else if (running && !(t instanceof ClosedByInterruptException)) {
+          // Only log if it is still running, otherwise, it just the interrupt caused by the stop.
             LOG.info("Exception when fetching message on {}.", topicPart, t);
           }
           consumers.refresh(consumerEntry.getKey());


### PR DESCRIPTION
Modified the logic to log the exception only if the service is running, if the service shutdown is under progress then the “running” flag will be false.
Now the code wont log the “java.net.ConnectException: Connection refused” , while the service shutdown.
