### PR TITLE
use Files.move instead of File.renameTo so we can have options to rep…

### DIFF
--- a/twill-common/src/main/java/org/apache/twill/filesystem/LocalLocation.java
+++ b/twill-common/src/main/java/org/apache/twill/filesystem/LocalLocation.java
@@ -25,6 +25,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Deque;
@@ -176,9 +179,11 @@ final class LocalLocation implements Location {
   @Override
   public Location renameTo(Location destination) throws IOException {
     // destination will always be of the same type as this location
-    boolean success = file.renameTo(((LocalLocation) destination).file);
-    if (success) {
-      return new LocalLocation(locationFactory, ((LocalLocation) destination).file);
+    Path target = Files.move(file.toPath(), ((LocalLocation) destination).file.toPath(),
+                             StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+
+    if (target != null) {
+      return new LocalLocation(locationFactory, target.toFile());
     } else {
       return null;
     }


### PR DESCRIPTION
…lace existing files and perform atomic move, this allows us to support windows rename

JIRA : https://issues.apache.org/jira/browse/TWILL-156